### PR TITLE
Save theme color to local storage by category

### DIFF
--- a/src/hooks/ui/useThemeColor.tsx
+++ b/src/hooks/ui/useThemeColor.tsx
@@ -1,7 +1,49 @@
 import { darken, lighten, readableColor, rgba } from "polished";
+import { useCurrentCategories, type UseCurrentCategoriesType, type Category } from "../../stores/splits/useCurrentCategories";
 
-export function useThemeColor(baseColor?: string) {
-  const primary = baseColor || "#be123c";
+// Optional enhancement: if no baseColor is provided, attempt to derive it from
+// the last selected category stored in localStorage and the persisted
+// categories store. You can also pass a categoryId explicitly as the second
+// argument to target a specific category.
+export function useThemeColor(baseColor?: string, categoryId?: string) {
+  const categories = useCurrentCategories((state: UseCurrentCategoriesType) => state.categories);
+
+  // 1) Explicit color always wins
+  let primary: string | undefined = baseColor;
+
+  // 2) If a categoryId is provided, try to find its color from the store
+  if (!primary && categoryId) {
+    const found = categories.find((c: Category) => c.id === categoryId);
+    if (found?.color) primary = found.color;
+  }
+
+  // 3) Fallback to last selected category id from localStorage
+  if (!primary && typeof window !== "undefined") {
+    try {
+      const LAST_CATEGORY_KEY = "fitoras_last_selected_category";
+      const lastCategoryId = localStorage.getItem(LAST_CATEGORY_KEY);
+      if (lastCategoryId) {
+        const fromStore = categories.find((c: Category) => c.id === lastCategoryId)?.color;
+        if (fromStore) primary = fromStore;
+
+        if (!primary) {
+          // As a final fallback, read persisted categories directly (shape from zustand persist)
+          const RAW_CATEGORIES_KEY = "fitoras_categories";
+          const raw = localStorage.getItem(RAW_CATEGORIES_KEY);
+          if (raw) {
+            const parsed = JSON.parse(raw) as { state?: { categories?: Category[] } } | undefined;
+            const persistedCategories = parsed?.state?.categories;
+            const fromPersist = persistedCategories?.find((c: Category) => c.id === lastCategoryId)?.color;
+            if (fromPersist) primary = fromPersist;
+          }
+        }
+      }
+    } catch {
+      // ignore parsing/localStorage errors and continue to default
+    }
+  }
+
+  if (!primary) primary = "#be123c";
 
   const textOnPrimary = readableColor(primary, "#000000", "#ffffff", false);
   const dark = darken(0.1, primary);

--- a/src/pages/splits/SplitControlPage.tsx
+++ b/src/pages/splits/SplitControlPage.tsx
@@ -21,7 +21,7 @@ const SplitControlPage = () => {
   const { id } = useParams<{ id: string }>();
   const { categories, selectedCategoryId } = useCategoryControl();
 
-  const theme = useThemeColor(currentSplit?.category?.color);
+  const theme = useThemeColor(currentSplit?.category?.color, selectedCategoryId ?? undefined);
   const { isDesktop, isMobile } = useBreakpoint();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isSelectedCollapsed, setIsSelectedCollapsed] = useState(false);


### PR DESCRIPTION
Enable `useThemeColor` to use persisted category colors from localStorage and update `SplitControlPage` to reflect the active category's color.

---
<a href="https://cursor.com/background-agent?bcId=bc-21b6f75a-a342-4436-a805-bf6b99af154c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21b6f75a-a342-4436-a805-bf6b99af154c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

