### PR TITLE
feat: add cookie consent banner for Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,15 +18,12 @@
     <meta property="og:url" content="https://fitoras.vercel.app" />
 
     <link rel="stylesheet" href="/src/index.css" />
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MH8B06QZVT"></script>
+    <!-- Google Analytics is loaded only after the user consents (see src/hooks/useGoogleAnalytics.ts) -->
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-MH8B06QZVT");
+      window.gtag = function () {
+        window.dataLayer.push(arguments);
+      };
     </script>
     <title>Fitoras | Exercises & Workout</title>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,20 @@
+import { useState } from "react";
 import NavBar from "./components/common/navBar/NavBar";
+import CookieConsent from "./components/common/CookieConsent";
 import AppRoutes from "./routes/router";
 import { useInitializeStores } from "./hooks/useInitializeStores";
+import {
+  useGoogleAnalytics,
+  getConsentStatus,
+  type ConsentStatus,
+} from "./hooks/useGoogleAnalytics";
+
 function App() {
   useInitializeStores();
+
+  const [consent, setConsent] = useState<ConsentStatus>(getConsentStatus);
+
+  useGoogleAnalytics(consent);
 
   return (
     <>
@@ -10,6 +22,9 @@ function App() {
         <NavBar />
         <AppRoutes />
       </div>
+
+      {/* Show the banner only when the user hasn't decided yet */}
+      {consent === null && <CookieConsent onConsent={setConsent} />}
     </>
   );
 }

--- a/src/components/common/CookieConsent.tsx
+++ b/src/components/common/CookieConsent.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Cookie, X } from "lucide-react";
+import { type ConsentStatus, setConsentStatus } from "@/hooks/useGoogleAnalytics";
+
+interface CookieConsentProps {
+  onConsent: (status: "accepted" | "declined") => void;
+}
+
+const CookieConsent = ({ onConsent }: CookieConsentProps) => {
+  const [visible, setVisible] = useState(true);
+
+  const handleAccept = () => {
+    setConsentStatus("accepted");
+    setVisible(false);
+    onConsent("accepted");
+  };
+
+  const handleDecline = () => {
+    setConsentStatus("declined");
+    setVisible(false);
+    onConsent("declined");
+  };
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          role="dialog"
+          aria-modal="false"
+          aria-label="Cookie consent"
+          initial={{ y: 100, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 100, opacity: 0 }}
+          transition={{ type: "spring", stiffness: 260, damping: 24 }}
+          className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-lg"
+        >
+          <div className="relative bg-white border border-rose-100 rounded-2xl shadow-xl px-5 py-4 flex flex-col gap-3">
+            {/* Dismiss button */}
+            <button
+              onClick={handleDecline}
+              aria-label="Decline and close cookie banner"
+              className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <X size={18} />
+            </button>
+
+            {/* Header */}
+            <div className="flex items-center gap-2 pr-6">
+              <Cookie size={20} className="text-rose-500 shrink-0" aria-hidden="true" />
+              <p className="text-sm font-semibold text-gray-800">We use cookies</p>
+            </div>
+
+            {/* Body */}
+            <p className="text-xs text-gray-500 leading-relaxed">
+              We use Google Analytics to understand how visitors interact with Fitoras. No personal data
+              is sold or shared. You can accept or decline analytics cookies at any time.
+            </p>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 justify-end">
+              <button
+                onClick={handleDecline}
+                className="text-xs px-4 py-2 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors font-medium"
+              >
+                Decline
+              </button>
+              <button
+                onClick={handleAccept}
+                className="text-xs px-4 py-2 rounded-lg bg-rose-500 hover:bg-rose-600 text-white transition-colors font-medium"
+              >
+                Accept analytics
+              </button>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export type { ConsentStatus };
+export default CookieConsent;

--- a/src/hooks/useGoogleAnalytics.ts
+++ b/src/hooks/useGoogleAnalytics.ts
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+
+const GA_MEASUREMENT_ID = "G-MH8B06QZVT";
+const GA_CONSENT_KEY = "ga_consent";
+
+export type ConsentStatus = "accepted" | "declined" | null;
+
+export function getConsentStatus(): ConsentStatus {
+  const stored = localStorage.getItem(GA_CONSENT_KEY);
+  if (stored === "accepted" || stored === "declined") return stored;
+  return null;
+}
+
+export function setConsentStatus(status: "accepted" | "declined"): void {
+  localStorage.setItem(GA_CONSENT_KEY, status);
+}
+
+function loadGAScript(): void {
+  if (document.getElementById("ga-script")) return;
+
+  const script = document.createElement("script");
+  script.id = "ga-script";
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+  document.head.appendChild(script);
+
+  script.onload = () => {
+    window.dataLayer = window.dataLayer || [];
+    function gtag(...args: unknown[]) {
+      window.dataLayer.push(args);
+    }
+    window.gtag = gtag;
+    gtag("js", new Date());
+    gtag("config", GA_MEASUREMENT_ID);
+  };
+}
+
+function removeGAScript(): void {
+  const script = document.getElementById("ga-script");
+  if (script) script.remove();
+
+  // Clear GA cookies
+  document.cookie = `_ga=; Max-Age=0; path=/; domain=${window.location.hostname}`;
+  document.cookie = `_ga_${GA_MEASUREMENT_ID.replace("G-", "")}=; Max-Age=0; path=/; domain=${window.location.hostname}`;
+}
+
+export function useGoogleAnalytics(consent: ConsentStatus): void {
+  useEffect(() => {
+    if (consent === "accepted") {
+      loadGAScript();
+    } else if (consent === "declined") {
+      removeGAScript();
+    }
+  }, [consent]);
+}

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,5 @@
+// Type declarations for Google Analytics gtag
+interface Window {
+  dataLayer: unknown[];
+  gtag: (...args: unknown[]) => void;
+}


### PR DESCRIPTION
## Summary

Adds a GDPR-friendly cookie consent system that gates Google Analytics loading behind explicit user consent.

### Changes

- **`index.html`** — Removed the unconditional GA `<script>` tags. A lightweight `window.gtag` / `window.dataLayer` stub is kept so nothing breaks before consent.
- **`src/hooks/useGoogleAnalytics.ts`** — New hook that dynamically injects the GA script tag when consent is `"accepted"` and cleans up GA cookies when `"declined"`. Consent is persisted in `localStorage` under `ga_consent`.
- **`src/components/common/CookieConsent.tsx`** — Animated bottom banner (Framer Motion) with **Accept analytics** and **Decline** buttons, matching the Fitoras rose-500 design language.
- **`src/App.tsx`** — Reads the stored consent on mount, passes it to `useGoogleAnalytics`, and renders `<CookieConsent>` only when the user hasn't decided yet.
- **`src/types/gtag.d.ts`** — TypeScript declarations for `window.gtag` and `window.dataLayer`.

### Behavior

- First visit → banner appears at the bottom of the screen.
- Accept → GA script is injected, consent saved, banner dismissed.
- Decline / close (×) → GA is never loaded, GA cookies cleared, consent saved, banner dismissed.
- Subsequent visits → banner is not shown again; GA loads (or not) based on saved preference.